### PR TITLE
Update plugin.py

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -163,10 +163,8 @@ class BasePlugin:
                 if Command == 'Off':
                     SendCommandCloud(DeviceID, 'switch_led_' + str(Unit), False)
                     UpdateDevice(DeviceID, Unit, 'Off', 0, 0)
-                elif Command == 'On':
-                    SendCommandCloud(DeviceID, 'switch_led_' + str(Unit), True)
-                    UpdateDevice(DeviceID, Unit, 'On', 1, 0)
                 elif Command == 'Set Level':
+                    SendCommandCloud(DeviceID, 'switch_led_' + str(Unit), True)
                     SendCommandCloud(DeviceID, 'bright_value_' + str(Unit), Level)
                     UpdateDevice(DeviceID, Unit, Level, 1, 0)
 


### PR DESCRIPTION
I bought a Moes dimmer and Domoticz would only turn it "off" but not "on". Dimmers only seem to use the "Set Level" command so I removed the "On" command and moved that command inside of the "Set Level" command. Now my dimmer works with Domoticz.